### PR TITLE
Fix NumberFormatException

### DIFF
--- a/src/main/java/ch/dvbern/oss/lib/beanvalidation/embeddables/IBAN.java
+++ b/src/main/java/ch/dvbern/oss/lib/beanvalidation/embeddables/IBAN.java
@@ -24,6 +24,8 @@ import javax.validation.constraints.Size;
 
 import ch.dvbern.oss.lib.beanvalidation.ValidIBANNummer;
 
+import static ch.dvbern.oss.lib.beanvalidation.util.StringHelper.trimLeadingZeros;
+
 /**
  * IBAN
  */
@@ -73,7 +75,7 @@ public class IBAN implements Serializable {
 
 	@Override
 	public String toString() {
-		String retVal = null;
+		String retVal;
 		if (iban != null) {
 			try {
 				retVal = new ch.dvbern.oss.datatypes.IBAN(iban).toString();
@@ -91,12 +93,15 @@ public class IBAN implements Serializable {
 	}
 
 	/**
-	 * Die Banken aus Nil+ haben die Clearing-Nummer nicht zwingend 5-stellig. Die aus der IBAN bezogene Clearing-Nummer ist aber immer
+	 * Die gewuenschte Clearingnummer wird manchmal ohne fuehrende Nullen gewuscht.
+	 * Die aus der IBAN bezogene Clearing-Nummer ist aber immer
 	 * 5-stellig, zum Vergleich muss sie daher mit führenden Nullen erweitert werden.
 	 *
-	 * @return die ClearingNummer
+	 * @return die ClearingNummer (aka BC)
 	 */
 	public String extractClearingNumberWithoutLeadingZeros() {
-		return Integer.valueOf(extractClearingNumber()).toString();
+		return trimLeadingZeros(extractClearingNumber());
 	}
+
+
 }

--- a/src/main/java/ch/dvbern/oss/lib/beanvalidation/util/StringHelper.java
+++ b/src/main/java/ch/dvbern/oss/lib/beanvalidation/util/StringHelper.java
@@ -1,0 +1,42 @@
+package ch.dvbern.oss.lib.beanvalidation.util;
+
+/**
+ * to avoid external dependencies we add our own StringHelper
+ */
+public class StringHelper {
+
+	public StringHelper() {
+		//util, no init
+	}
+
+	/**
+	 *
+	 * @param source inputstring
+	 * @return inputstring withoug leading zeroes, returns same string if no leading zeroes
+	 * exit, returns null if input string was null
+	 */
+	public static String trimLeadingZeros(String source) {
+		if (source == null) {
+			return null;
+		}
+
+		int length = source.length();
+		if (length < 2) {
+			return source;
+		}
+
+		int i;
+		for (i = 0; i < length - 1; i++) {
+			char c = source.charAt(i);
+			if (c != '0') {
+				break;
+			}
+		}
+
+		if (i == 0) {
+			return source;
+		}
+
+		return source.substring(i);
+	}
+}

--- a/src/test/java/ch/dvbern/oss/lib/beanvalidation/ValidIBANTest.java
+++ b/src/test/java/ch/dvbern/oss/lib/beanvalidation/ValidIBANTest.java
@@ -18,6 +18,7 @@ package ch.dvbern.oss.lib.beanvalidation;
 import javax.validation.Valid;
 
 import ch.dvbern.oss.lib.beanvalidation.embeddables.IBAN;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static ch.dvbern.oss.lib.beanvalidation.util.ValidationTestHelper.assertNotViolated;
@@ -52,6 +53,48 @@ public class ValidIBANTest {
 
 		bean.setIban(new IBAN(""));
 		assertViolated(ValidIBANNummer.class, bean, "iban");
+
+		bean.setIban(new IBAN("NL53ABNA0205986478"));
+		assertNotViolated(ValidIBANNummer.class, bean, "iban");
+	}
+
+	@Test
+	public void testClearingNumberExtraction() {
+
+		Bean bean = new Bean();
+		bean.setIban(new IBAN("NL53ABNA0205986478"));
+		assertNotViolated(ValidIBANNummer.class, bean, "iban");
+		bean.getIban().extractClearingNumber();
+		bean.getIban().extractClearingNumberWithoutLeadingZeros();
+		Assert.assertEquals(bean.getIban().extractClearingNumberWithoutLeadingZeros(), bean.getIban()
+				.extractClearingNumber());
+
+		bean.setIban(new IBAN("CH39 0900 0000 3066 3817 2"));
+		assertNotViolated(ValidIBANNummer.class, bean, "iban");
+		String leadingZeroes = bean.getIban().extractClearingNumber();
+		String noLeadingZeroes = bean.getIban().extractClearingNumberWithoutLeadingZeros();
+		Assert.assertEquals("09000", leadingZeroes);
+		Assert.assertEquals("9000", noLeadingZeroes);
+
+		bean = new Bean();
+		bean.setIban(new IBAN("CH123456"));
+		assertViolated(ValidIBANNummer.class, bean, "iban");
+
+		try {
+			bean.getIban().extractClearingNumber();
+			Assert.fail("Invalid Iban should trigger exception when calling extractClearingNumber");
+		} catch (IllegalArgumentException e) {
+			//expected
+		}
+
+		try {
+			bean.getIban().extractClearingNumberWithoutLeadingZeros();
+			Assert.fail("Invalid Iban should trigger exception when calling extractClearingNumber");
+		} catch (IllegalArgumentException e) {
+			//expected
+		}
+		
+
 	}
 
 	public static class Bean {


### PR DESCRIPTION
Fix Exception that happend when IBAN.extractClearingNumbWithoutLeadingZeros was called on an IBAN that does have non-numeric characters in its clearing number part (i.e. NL)

The function was changed to operate on non-numeric strings without crashing.